### PR TITLE
Refactor OutboxMessage and user service event handling

### DIFF
--- a/gen/processor/v1/processor.pb.go
+++ b/gen/processor/v1/processor.pb.go
@@ -25,7 +25,7 @@ type OutboxMessage struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	EventId       string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	EventType     string                 `protobuf:"bytes,2,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
-	Payload       []byte                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
+	Payload       string                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
 	Published     bool                   `protobuf:"varint,4,opt,name=published,proto3" json:"published,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -75,11 +75,11 @@ func (x *OutboxMessage) GetEventType() string {
 	return ""
 }
 
-func (x *OutboxMessage) GetPayload() []byte {
+func (x *OutboxMessage) GetPayload() string {
 	if x != nil {
 		return x.Payload
 	}
-	return nil
+	return ""
 }
 
 func (x *OutboxMessage) GetPublished() bool {
@@ -186,7 +186,7 @@ const file_processor_v1_processor_proto_rawDesc = "" +
 	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x1d\n" +
 	"\n" +
 	"event_type\x18\x02 \x01(\tR\teventType\x12\x18\n" +
-	"\apayload\x18\x03 \x01(\fR\apayload\x12\x1c\n" +
+	"\apayload\x18\x03 \x01(\tR\apayload\x12\x1c\n" +
 	"\tpublished\x18\x04 \x01(\bR\tpublished\";\n" +
 	"\x1bProcessOutboxMessageRequest\x12\x1c\n" +
 	"\tpublished\x18\x01 \x01(\bR\tpublished\"G\n" +

--- a/gen/processor/v1/processorv1connect/processor.connect.go
+++ b/gen/processor/v1/processorv1connect/processor.connect.go
@@ -11,6 +11,7 @@ import (
 	strings "strings"
 
 	connect "connectrpc.com/connect"
+
 	v1 "github.com/yaninyzwitty/threads-go-backend/gen/processor/v1"
 )
 

--- a/gen/user/v1/user.pb.go
+++ b/gen/user/v1/user.pb.go
@@ -7,14 +7,12 @@
 package userv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
-	v1 "github.com/yaninyzwitty/threads-go-backend/gen/processor/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -134,7 +132,10 @@ func (x *User) GetPassword() string {
 
 type OutboxEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	OutboxMessage *v1.OutboxMessage      `protobuf:"bytes,1,opt,name=outbox_message,json=outboxMessage,proto3" json:"outbox_message,omitempty"`
+	EventId       string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	EventType     string                 `protobuf:"bytes,2,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
+	Payload       string                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
+	Published     bool                   `protobuf:"varint,4,opt,name=published,proto3" json:"published,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -169,11 +170,32 @@ func (*OutboxEvent) Descriptor() ([]byte, []int) {
 	return file_user_v1_user_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *OutboxEvent) GetOutboxMessage() *v1.OutboxMessage {
+func (x *OutboxEvent) GetEventId() string {
 	if x != nil {
-		return x.OutboxMessage
+		return x.EventId
 	}
-	return nil
+	return ""
+}
+
+func (x *OutboxEvent) GetEventType() string {
+	if x != nil {
+		return x.EventType
+	}
+	return ""
+}
+
+func (x *OutboxEvent) GetPayload() string {
+	if x != nil {
+		return x.Payload
+	}
+	return ""
+}
+
+func (x *OutboxEvent) GetPublished() bool {
+	if x != nil {
+		return x.Published
+	}
+	return false
 }
 
 type FollowedEvent struct {
@@ -1403,11 +1425,203 @@ func (x *DecrementFollowingAndFollowerCountResponse) GetDecremented() bool {
 	return false
 }
 
+type FollowUserCachedRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	FollowingId   int64                  `protobuf:"varint,2,opt,name=following_id,json=followingId,proto3" json:"following_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FollowUserCachedRequest) Reset() {
+	*x = FollowUserCachedRequest{}
+	mi := &file_user_v1_user_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FollowUserCachedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FollowUserCachedRequest) ProtoMessage() {}
+
+func (x *FollowUserCachedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_user_v1_user_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FollowUserCachedRequest.ProtoReflect.Descriptor instead.
+func (*FollowUserCachedRequest) Descriptor() ([]byte, []int) {
+	return file_user_v1_user_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *FollowUserCachedRequest) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *FollowUserCachedRequest) GetFollowingId() int64 {
+	if x != nil {
+		return x.FollowingId
+	}
+	return 0
+}
+
+type FollowUserCachedResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FollowUserCachedResponse) Reset() {
+	*x = FollowUserCachedResponse{}
+	mi := &file_user_v1_user_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FollowUserCachedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FollowUserCachedResponse) ProtoMessage() {}
+
+func (x *FollowUserCachedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_user_v1_user_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FollowUserCachedResponse.ProtoReflect.Descriptor instead.
+func (*FollowUserCachedResponse) Descriptor() ([]byte, []int) {
+	return file_user_v1_user_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *FollowUserCachedResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+type UnfollowUserCachedRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        int64                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	FollowingId   int64                  `protobuf:"varint,2,opt,name=following_id,json=followingId,proto3" json:"following_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnfollowUserCachedRequest) Reset() {
+	*x = UnfollowUserCachedRequest{}
+	mi := &file_user_v1_user_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnfollowUserCachedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnfollowUserCachedRequest) ProtoMessage() {}
+
+func (x *UnfollowUserCachedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_user_v1_user_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnfollowUserCachedRequest.ProtoReflect.Descriptor instead.
+func (*UnfollowUserCachedRequest) Descriptor() ([]byte, []int) {
+	return file_user_v1_user_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *UnfollowUserCachedRequest) GetUserId() int64 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *UnfollowUserCachedRequest) GetFollowingId() int64 {
+	if x != nil {
+		return x.FollowingId
+	}
+	return 0
+}
+
+type UnfollowUserCachedResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnfollowUserCachedResponse) Reset() {
+	*x = UnfollowUserCachedResponse{}
+	mi := &file_user_v1_user_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnfollowUserCachedResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnfollowUserCachedResponse) ProtoMessage() {}
+
+func (x *UnfollowUserCachedResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_user_v1_user_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnfollowUserCachedResponse.ProtoReflect.Descriptor instead.
+func (*UnfollowUserCachedResponse) Descriptor() ([]byte, []int) {
+	return file_user_v1_user_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *UnfollowUserCachedResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
 var File_user_v1_user_proto protoreflect.FileDescriptor
 
 const file_user_v1_user_proto_rawDesc = "" +
 	"\n" +
-	"\x12user/v1/user.proto\x12\auser.v1\x1a\x1cprocessor/v1/processor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc0\x02\n" +
+	"\x12user/v1/user.proto\x12\auser.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc0\x02\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1b\n" +
@@ -1420,9 +1634,13 @@ const file_user_v1_user_proto_rawDesc = "" +
 	"created_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
 	"updated_at\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12\x1a\n" +
-	"\bpassword\x18\t \x01(\tR\bpassword\"Q\n" +
-	"\vOutboxEvent\x12B\n" +
-	"\x0eoutbox_message\x18\x01 \x01(\v2\x1b.processor.v1.OutboxMessageR\routboxMessage\"\xa3\x01\n" +
+	"\bpassword\x18\t \x01(\tR\bpassword\"\x7f\n" +
+	"\vOutboxEvent\x12\x19\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x1d\n" +
+	"\n" +
+	"event_type\x18\x02 \x01(\tR\teventType\x12\x18\n" +
+	"\apayload\x18\x03 \x01(\tR\apayload\x12\x1c\n" +
+	"\tpublished\x18\x04 \x01(\bR\tpublished\"\xa3\x01\n" +
 	"\rFollowedEvent\x12\x19\n" +
 	"\bevent_id\x18\x01 \x01(\tR\aeventId\x12\x17\n" +
 	"\auser_id\x18\x02 \x01(\x03R\x06userId\x12!\n" +
@@ -1494,7 +1712,17 @@ const file_user_v1_user_proto_rawDesc = "" +
 	")DecrementFollowingAndFollowerCountRequest\x12C\n" +
 	"\x10unfollowed_event\x18\x01 \x01(\v2\x18.user.v1.UnfollowedEventR\x0funfollowedEvent\"N\n" +
 	"*DecrementFollowingAndFollowerCountResponse\x12 \n" +
-	"\vdecremented\x18\x01 \x01(\bR\vdecremented2\xb5\a\n" +
+	"\vdecremented\x18\x01 \x01(\bR\vdecremented\"U\n" +
+	"\x17FollowUserCachedRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12!\n" +
+	"\ffollowing_id\x18\x02 \x01(\x03R\vfollowingId\"4\n" +
+	"\x18FollowUserCachedResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\"W\n" +
+	"\x19UnfollowUserCachedRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\x03R\x06userId\x12!\n" +
+	"\ffollowing_id\x18\x02 \x01(\x03R\vfollowingId\"6\n" +
+	"\x1aUnfollowUserCachedResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess2\xed\b\n" +
 	"\vUserService\x12B\n" +
 	"\tLoginUser\x12\x19.user.v1.LoginUserRequest\x1a\x1a.user.v1.LoginUserResponse\x12E\n" +
 	"\n" +
@@ -1510,7 +1738,9 @@ const file_user_v1_user_proto_rawDesc = "" +
 	"FollowUser\x12\x1a.user.v1.FollowUserRequest\x1a\x1b.user.v1.FollowUserResponse\x12K\n" +
 	"\fUnfollowUser\x12\x1c.user.v1.UnfollowUserRequest\x1a\x1d.user.v1.UnfollowUserResponse\x12\x8d\x01\n" +
 	"\"IncrementFollowingAndFollowerCount\x122.user.v1.IncrementFollowingAndFollowerCountRequest\x1a3.user.v1.IncrementFollowingAndFollowerCountResponse\x12\x8d\x01\n" +
-	"\"DecrementFollowingAndFollowerCount\x122.user.v1.DecrementFollowingAndFollowerCountRequest\x1a3.user.v1.DecrementFollowingAndFollowerCountResponseB\x8a\x01\n" +
+	"\"DecrementFollowingAndFollowerCount\x122.user.v1.DecrementFollowingAndFollowerCountRequest\x1a3.user.v1.DecrementFollowingAndFollowerCountResponse\x12W\n" +
+	"\x10FollowUserCached\x12 .user.v1.FollowUserCachedRequest\x1a!.user.v1.FollowUserCachedResponse\x12]\n" +
+	"\x12UnfollowUserCached\x12\".user.v1.UnfollowUserCachedRequest\x1a#.user.v1.UnfollowUserCachedResponseB\x8a\x01\n" +
 	"\vcom.user.v1B\tUserProtoP\x01Z3github.com/bufbuild/buf-examples/gen/user/v1;userv1\xa2\x02\x03UXX\xaa\x02\aUser.V1\xca\x02\aUser\\V1\xe2\x02\x13User\\V1\\GPBMetadata\xea\x02\bUser::V1b\x06proto3"
 
 var (
@@ -1525,7 +1755,7 @@ func file_user_v1_user_proto_rawDescGZIP() []byte {
 	return file_user_v1_user_proto_rawDescData
 }
 
-var file_user_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_user_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_user_v1_user_proto_goTypes = []any{
 	(*User)(nil),                                       // 0: user.v1.User
 	(*OutboxEvent)(nil),                                // 1: user.v1.OutboxEvent
@@ -1553,48 +1783,54 @@ var file_user_v1_user_proto_goTypes = []any{
 	(*IncrementFollowingAndFollowerCountResponse)(nil), // 23: user.v1.IncrementFollowingAndFollowerCountResponse
 	(*DecrementFollowingAndFollowerCountRequest)(nil),  // 24: user.v1.DecrementFollowingAndFollowerCountRequest
 	(*DecrementFollowingAndFollowerCountResponse)(nil), // 25: user.v1.DecrementFollowingAndFollowerCountResponse
-	(*timestamppb.Timestamp)(nil),                      // 26: google.protobuf.Timestamp
-	(*v1.OutboxMessage)(nil),                           // 27: processor.v1.OutboxMessage
+	(*FollowUserCachedRequest)(nil),                    // 26: user.v1.FollowUserCachedRequest
+	(*FollowUserCachedResponse)(nil),                   // 27: user.v1.FollowUserCachedResponse
+	(*UnfollowUserCachedRequest)(nil),                  // 28: user.v1.UnfollowUserCachedRequest
+	(*UnfollowUserCachedResponse)(nil),                 // 29: user.v1.UnfollowUserCachedResponse
+	(*timestamppb.Timestamp)(nil),                      // 30: google.protobuf.Timestamp
 }
 var file_user_v1_user_proto_depIdxs = []int32{
-	26, // 0: user.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	26, // 1: user.v1.User.updated_at:type_name -> google.protobuf.Timestamp
-	27, // 2: user.v1.OutboxEvent.outbox_message:type_name -> processor.v1.OutboxMessage
-	26, // 3: user.v1.FollowedEvent.followed_at:type_name -> google.protobuf.Timestamp
-	26, // 4: user.v1.UnfollowedEvent.unfollowed_at:type_name -> google.protobuf.Timestamp
-	0,  // 5: user.v1.CreateUserResponse.user:type_name -> user.v1.User
-	0,  // 6: user.v1.UpdateUserResponse.user:type_name -> user.v1.User
-	0,  // 7: user.v1.GetUserByIDResponse.user:type_name -> user.v1.User
-	0,  // 8: user.v1.ListUsersResponse.users:type_name -> user.v1.User
-	2,  // 9: user.v1.IncrementFollowingAndFollowerCountRequest.followed_event:type_name -> user.v1.FollowedEvent
-	3,  // 10: user.v1.DecrementFollowingAndFollowerCountRequest.unfollowed_event:type_name -> user.v1.UnfollowedEvent
-	4,  // 11: user.v1.UserService.LoginUser:input_type -> user.v1.LoginUserRequest
-	6,  // 12: user.v1.UserService.CreateUser:input_type -> user.v1.CreateUserRequest
-	8,  // 13: user.v1.UserService.RefreshToken:input_type -> user.v1.RefreshTokenRequest
-	10, // 14: user.v1.UserService.UpdateUser:input_type -> user.v1.UpdateUserRequest
-	20, // 15: user.v1.UserService.DeleteUser:input_type -> user.v1.DeleteUserRequest
-	12, // 16: user.v1.UserService.GetUserByID:input_type -> user.v1.GetUserByIDRequest
-	14, // 17: user.v1.UserService.ListUsers:input_type -> user.v1.ListUsersRequest
-	16, // 18: user.v1.UserService.FollowUser:input_type -> user.v1.FollowUserRequest
-	18, // 19: user.v1.UserService.UnfollowUser:input_type -> user.v1.UnfollowUserRequest
-	22, // 20: user.v1.UserService.IncrementFollowingAndFollowerCount:input_type -> user.v1.IncrementFollowingAndFollowerCountRequest
-	24, // 21: user.v1.UserService.DecrementFollowingAndFollowerCount:input_type -> user.v1.DecrementFollowingAndFollowerCountRequest
-	5,  // 22: user.v1.UserService.LoginUser:output_type -> user.v1.LoginUserResponse
-	7,  // 23: user.v1.UserService.CreateUser:output_type -> user.v1.CreateUserResponse
-	9,  // 24: user.v1.UserService.RefreshToken:output_type -> user.v1.RefreshTokenResponse
-	11, // 25: user.v1.UserService.UpdateUser:output_type -> user.v1.UpdateUserResponse
-	21, // 26: user.v1.UserService.DeleteUser:output_type -> user.v1.DeleteUserResponse
-	13, // 27: user.v1.UserService.GetUserByID:output_type -> user.v1.GetUserByIDResponse
-	15, // 28: user.v1.UserService.ListUsers:output_type -> user.v1.ListUsersResponse
-	17, // 29: user.v1.UserService.FollowUser:output_type -> user.v1.FollowUserResponse
-	19, // 30: user.v1.UserService.UnfollowUser:output_type -> user.v1.UnfollowUserResponse
-	23, // 31: user.v1.UserService.IncrementFollowingAndFollowerCount:output_type -> user.v1.IncrementFollowingAndFollowerCountResponse
-	25, // 32: user.v1.UserService.DecrementFollowingAndFollowerCount:output_type -> user.v1.DecrementFollowingAndFollowerCountResponse
-	22, // [22:33] is the sub-list for method output_type
-	11, // [11:22] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	30, // 0: user.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	30, // 1: user.v1.User.updated_at:type_name -> google.protobuf.Timestamp
+	30, // 2: user.v1.FollowedEvent.followed_at:type_name -> google.protobuf.Timestamp
+	30, // 3: user.v1.UnfollowedEvent.unfollowed_at:type_name -> google.protobuf.Timestamp
+	0,  // 4: user.v1.CreateUserResponse.user:type_name -> user.v1.User
+	0,  // 5: user.v1.UpdateUserResponse.user:type_name -> user.v1.User
+	0,  // 6: user.v1.GetUserByIDResponse.user:type_name -> user.v1.User
+	0,  // 7: user.v1.ListUsersResponse.users:type_name -> user.v1.User
+	2,  // 8: user.v1.IncrementFollowingAndFollowerCountRequest.followed_event:type_name -> user.v1.FollowedEvent
+	3,  // 9: user.v1.DecrementFollowingAndFollowerCountRequest.unfollowed_event:type_name -> user.v1.UnfollowedEvent
+	4,  // 10: user.v1.UserService.LoginUser:input_type -> user.v1.LoginUserRequest
+	6,  // 11: user.v1.UserService.CreateUser:input_type -> user.v1.CreateUserRequest
+	8,  // 12: user.v1.UserService.RefreshToken:input_type -> user.v1.RefreshTokenRequest
+	10, // 13: user.v1.UserService.UpdateUser:input_type -> user.v1.UpdateUserRequest
+	20, // 14: user.v1.UserService.DeleteUser:input_type -> user.v1.DeleteUserRequest
+	12, // 15: user.v1.UserService.GetUserByID:input_type -> user.v1.GetUserByIDRequest
+	14, // 16: user.v1.UserService.ListUsers:input_type -> user.v1.ListUsersRequest
+	16, // 17: user.v1.UserService.FollowUser:input_type -> user.v1.FollowUserRequest
+	18, // 18: user.v1.UserService.UnfollowUser:input_type -> user.v1.UnfollowUserRequest
+	22, // 19: user.v1.UserService.IncrementFollowingAndFollowerCount:input_type -> user.v1.IncrementFollowingAndFollowerCountRequest
+	24, // 20: user.v1.UserService.DecrementFollowingAndFollowerCount:input_type -> user.v1.DecrementFollowingAndFollowerCountRequest
+	26, // 21: user.v1.UserService.FollowUserCached:input_type -> user.v1.FollowUserCachedRequest
+	28, // 22: user.v1.UserService.UnfollowUserCached:input_type -> user.v1.UnfollowUserCachedRequest
+	5,  // 23: user.v1.UserService.LoginUser:output_type -> user.v1.LoginUserResponse
+	7,  // 24: user.v1.UserService.CreateUser:output_type -> user.v1.CreateUserResponse
+	9,  // 25: user.v1.UserService.RefreshToken:output_type -> user.v1.RefreshTokenResponse
+	11, // 26: user.v1.UserService.UpdateUser:output_type -> user.v1.UpdateUserResponse
+	21, // 27: user.v1.UserService.DeleteUser:output_type -> user.v1.DeleteUserResponse
+	13, // 28: user.v1.UserService.GetUserByID:output_type -> user.v1.GetUserByIDResponse
+	15, // 29: user.v1.UserService.ListUsers:output_type -> user.v1.ListUsersResponse
+	17, // 30: user.v1.UserService.FollowUser:output_type -> user.v1.FollowUserResponse
+	19, // 31: user.v1.UserService.UnfollowUser:output_type -> user.v1.UnfollowUserResponse
+	23, // 32: user.v1.UserService.IncrementFollowingAndFollowerCount:output_type -> user.v1.IncrementFollowingAndFollowerCountResponse
+	25, // 33: user.v1.UserService.DecrementFollowingAndFollowerCount:output_type -> user.v1.DecrementFollowingAndFollowerCountResponse
+	27, // 34: user.v1.UserService.FollowUserCached:output_type -> user.v1.FollowUserCachedResponse
+	29, // 35: user.v1.UserService.UnfollowUserCached:output_type -> user.v1.UnfollowUserCachedResponse
+	23, // [23:36] is the sub-list for method output_type
+	10, // [10:23] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_user_v1_user_proto_init() }
@@ -1608,7 +1844,7 @@ func file_user_v1_user_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_user_v1_user_proto_rawDesc), len(file_user_v1_user_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   26,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/user/v1/userv1connect/user.connect.go
+++ b/gen/user/v1/userv1connect/user.connect.go
@@ -60,6 +60,12 @@ const (
 	// UserServiceDecrementFollowingAndFollowerCountProcedure is the fully-qualified name of the
 	// UserService's DecrementFollowingAndFollowerCount RPC.
 	UserServiceDecrementFollowingAndFollowerCountProcedure = "/user.v1.UserService/DecrementFollowingAndFollowerCount"
+	// UserServiceFollowUserCachedProcedure is the fully-qualified name of the UserService's
+	// FollowUserCached RPC.
+	UserServiceFollowUserCachedProcedure = "/user.v1.UserService/FollowUserCached"
+	// UserServiceUnfollowUserCachedProcedure is the fully-qualified name of the UserService's
+	// UnfollowUserCached RPC.
+	UserServiceUnfollowUserCachedProcedure = "/user.v1.UserService/UnfollowUserCached"
 )
 
 // UserServiceClient is a client for the user.v1.UserService service.
@@ -75,6 +81,8 @@ type UserServiceClient interface {
 	UnfollowUser(context.Context, *connect.Request[v1.UnfollowUserRequest]) (*connect.Response[v1.UnfollowUserResponse], error)
 	IncrementFollowingAndFollowerCount(context.Context, *connect.Request[v1.IncrementFollowingAndFollowerCountRequest]) (*connect.Response[v1.IncrementFollowingAndFollowerCountResponse], error)
 	DecrementFollowingAndFollowerCount(context.Context, *connect.Request[v1.DecrementFollowingAndFollowerCountRequest]) (*connect.Response[v1.DecrementFollowingAndFollowerCountResponse], error)
+	FollowUserCached(context.Context, *connect.Request[v1.FollowUserCachedRequest]) (*connect.Response[v1.FollowUserCachedResponse], error)
+	UnfollowUserCached(context.Context, *connect.Request[v1.UnfollowUserCachedRequest]) (*connect.Response[v1.UnfollowUserCachedResponse], error)
 }
 
 // NewUserServiceClient constructs a client for the user.v1.UserService service. By default, it uses
@@ -154,6 +162,18 @@ func NewUserServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(userServiceMethods.ByName("DecrementFollowingAndFollowerCount")),
 			connect.WithClientOptions(opts...),
 		),
+		followUserCached: connect.NewClient[v1.FollowUserCachedRequest, v1.FollowUserCachedResponse](
+			httpClient,
+			baseURL+UserServiceFollowUserCachedProcedure,
+			connect.WithSchema(userServiceMethods.ByName("FollowUserCached")),
+			connect.WithClientOptions(opts...),
+		),
+		unfollowUserCached: connect.NewClient[v1.UnfollowUserCachedRequest, v1.UnfollowUserCachedResponse](
+			httpClient,
+			baseURL+UserServiceUnfollowUserCachedProcedure,
+			connect.WithSchema(userServiceMethods.ByName("UnfollowUserCached")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -170,6 +190,8 @@ type userServiceClient struct {
 	unfollowUser                       *connect.Client[v1.UnfollowUserRequest, v1.UnfollowUserResponse]
 	incrementFollowingAndFollowerCount *connect.Client[v1.IncrementFollowingAndFollowerCountRequest, v1.IncrementFollowingAndFollowerCountResponse]
 	decrementFollowingAndFollowerCount *connect.Client[v1.DecrementFollowingAndFollowerCountRequest, v1.DecrementFollowingAndFollowerCountResponse]
+	followUserCached                   *connect.Client[v1.FollowUserCachedRequest, v1.FollowUserCachedResponse]
+	unfollowUserCached                 *connect.Client[v1.UnfollowUserCachedRequest, v1.UnfollowUserCachedResponse]
 }
 
 // LoginUser calls user.v1.UserService.LoginUser.
@@ -227,6 +249,16 @@ func (c *userServiceClient) DecrementFollowingAndFollowerCount(ctx context.Conte
 	return c.decrementFollowingAndFollowerCount.CallUnary(ctx, req)
 }
 
+// FollowUserCached calls user.v1.UserService.FollowUserCached.
+func (c *userServiceClient) FollowUserCached(ctx context.Context, req *connect.Request[v1.FollowUserCachedRequest]) (*connect.Response[v1.FollowUserCachedResponse], error) {
+	return c.followUserCached.CallUnary(ctx, req)
+}
+
+// UnfollowUserCached calls user.v1.UserService.UnfollowUserCached.
+func (c *userServiceClient) UnfollowUserCached(ctx context.Context, req *connect.Request[v1.UnfollowUserCachedRequest]) (*connect.Response[v1.UnfollowUserCachedResponse], error) {
+	return c.unfollowUserCached.CallUnary(ctx, req)
+}
+
 // UserServiceHandler is an implementation of the user.v1.UserService service.
 type UserServiceHandler interface {
 	LoginUser(context.Context, *connect.Request[v1.LoginUserRequest]) (*connect.Response[v1.LoginUserResponse], error)
@@ -240,6 +272,8 @@ type UserServiceHandler interface {
 	UnfollowUser(context.Context, *connect.Request[v1.UnfollowUserRequest]) (*connect.Response[v1.UnfollowUserResponse], error)
 	IncrementFollowingAndFollowerCount(context.Context, *connect.Request[v1.IncrementFollowingAndFollowerCountRequest]) (*connect.Response[v1.IncrementFollowingAndFollowerCountResponse], error)
 	DecrementFollowingAndFollowerCount(context.Context, *connect.Request[v1.DecrementFollowingAndFollowerCountRequest]) (*connect.Response[v1.DecrementFollowingAndFollowerCountResponse], error)
+	FollowUserCached(context.Context, *connect.Request[v1.FollowUserCachedRequest]) (*connect.Response[v1.FollowUserCachedResponse], error)
+	UnfollowUserCached(context.Context, *connect.Request[v1.UnfollowUserCachedRequest]) (*connect.Response[v1.UnfollowUserCachedResponse], error)
 }
 
 // NewUserServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -315,6 +349,18 @@ func NewUserServiceHandler(svc UserServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(userServiceMethods.ByName("DecrementFollowingAndFollowerCount")),
 		connect.WithHandlerOptions(opts...),
 	)
+	userServiceFollowUserCachedHandler := connect.NewUnaryHandler(
+		UserServiceFollowUserCachedProcedure,
+		svc.FollowUserCached,
+		connect.WithSchema(userServiceMethods.ByName("FollowUserCached")),
+		connect.WithHandlerOptions(opts...),
+	)
+	userServiceUnfollowUserCachedHandler := connect.NewUnaryHandler(
+		UserServiceUnfollowUserCachedProcedure,
+		svc.UnfollowUserCached,
+		connect.WithSchema(userServiceMethods.ByName("UnfollowUserCached")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/user.v1.UserService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case UserServiceLoginUserProcedure:
@@ -339,6 +385,10 @@ func NewUserServiceHandler(svc UserServiceHandler, opts ...connect.HandlerOption
 			userServiceIncrementFollowingAndFollowerCountHandler.ServeHTTP(w, r)
 		case UserServiceDecrementFollowingAndFollowerCountProcedure:
 			userServiceDecrementFollowingAndFollowerCountHandler.ServeHTTP(w, r)
+		case UserServiceFollowUserCachedProcedure:
+			userServiceFollowUserCachedHandler.ServeHTTP(w, r)
+		case UserServiceUnfollowUserCachedProcedure:
+			userServiceUnfollowUserCachedHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -390,4 +440,12 @@ func (UnimplementedUserServiceHandler) IncrementFollowingAndFollowerCount(contex
 
 func (UnimplementedUserServiceHandler) DecrementFollowingAndFollowerCount(context.Context, *connect.Request[v1.DecrementFollowingAndFollowerCountRequest]) (*connect.Response[v1.DecrementFollowingAndFollowerCountResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("user.v1.UserService.DecrementFollowingAndFollowerCount is not implemented"))
+}
+
+func (UnimplementedUserServiceHandler) FollowUserCached(context.Context, *connect.Request[v1.FollowUserCachedRequest]) (*connect.Response[v1.FollowUserCachedResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("user.v1.UserService.FollowUserCached is not implemented"))
+}
+
+func (UnimplementedUserServiceHandler) UnfollowUserCached(context.Context, *connect.Request[v1.UnfollowUserCachedRequest]) (*connect.Response[v1.UnfollowUserCachedResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("user.v1.UserService.UnfollowUserCached is not implemented"))
 }

--- a/proto/processor/v1/processor.proto
+++ b/proto/processor/v1/processor.proto
@@ -6,7 +6,7 @@ package processor.v1;
 message OutboxMessage {
     string event_id = 1;
     string event_type = 2;
-    bytes payload = 3;
+    string payload = 3;
     bool published = 4;
 }
 

--- a/proto/user/v1/user.proto
+++ b/proto/user/v1/user.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 package user.v1;
-import "processor/v1/processor.proto";
 
 
 import "google/protobuf/timestamp.proto";
@@ -21,7 +20,10 @@ message User {
 }
 
 message OutboxEvent {
-  processor.v1.OutboxMessage outbox_message = 1;
+    string event_id = 1;
+    string event_type = 2;
+    string payload = 3;
+    bool published = 4;
 }
 
 message FollowedEvent {
@@ -149,6 +151,23 @@ message DecrementFollowingAndFollowerCountResponse {
   bool decremented = 1;
 }
 
+message FollowUserCachedRequest {
+  int64 user_id = 1;
+  int64 following_id = 2;
+}
+
+message FollowUserCachedResponse {
+  bool success = 1;
+}
+
+message UnfollowUserCachedRequest {
+  int64 user_id = 1;
+  int64 following_id = 2;
+}
+
+message UnfollowUserCachedResponse {
+  bool success = 1;
+}
 
 service UserService {
   rpc LoginUser(LoginUserRequest) returns (LoginUserResponse);
@@ -162,6 +181,8 @@ service UserService {
   rpc UnfollowUser(UnfollowUserRequest) returns (UnfollowUserResponse);
   rpc IncrementFollowingAndFollowerCount(IncrementFollowingAndFollowerCountRequest) returns (IncrementFollowingAndFollowerCountResponse);
   rpc DecrementFollowingAndFollowerCount(DecrementFollowingAndFollowerCountRequest) returns (DecrementFollowingAndFollowerCountResponse);
+  rpc FollowUserCached(FollowUserCachedRequest) returns (FollowUserCachedResponse);
+  rpc UnfollowUserCached(UnfollowUserCachedRequest) returns (UnfollowUserCachedResponse);
   
  
 

--- a/services/processor-service/controller/processor-controller.go
+++ b/services/processor-service/controller/processor-controller.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	processorv1 "github.com/yaninyzwitty/threads-go-backend/gen/processor/v1"
@@ -22,28 +24,37 @@ func NewProcessorController(repo *repository.ProcessorRepository) *ProcessorCont
 
 }
 
-func (c *ProcessorController) ProcessOutboxMessage(ctx context.Context, req *connect.Request[processorv1.ProcessOutboxMessageRequest]) (*connect.Response[processorv1.ProcessOutboxMessageResponse], error) {
+func (c *ProcessorController) ProcessOutboxMessage(
+	ctx context.Context,
+	req *connect.Request[processorv1.ProcessOutboxMessageRequest],
+) (*connect.Response[processorv1.ProcessOutboxMessageResponse], error) {
+
 	if req.Msg.Published {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("published messages cannot be processed"))
 	}
 
 	events, err := c.repo.GetOutboxMessages(ctx, req.Msg.Published, 10)
-
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to fetch outbox messages: %w", err))
 	}
+
+	var processed int
 
 	for _, event := range events {
 		if err := c.repo.PublishEvent(ctx, event); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			slog.Error("failed to publish event", "event_id", event.EventId, "event_type", event.EventType, "error", err)
+			continue // ❗ Don't stop the whole batch — continue with next
 		}
 
 		if err := c.repo.MarkEventAsPublished(ctx, event.EventId); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			slog.Error("failed to mark event as published", "event_id", event.EventId, "error", err)
+			continue
 		}
+
+		processed++
 	}
 
 	return connect.NewResponse(&processorv1.ProcessOutboxMessageResponse{
-		ProcessedCount: int32(len(events)),
+		ProcessedCount: int32(processed),
 	}), nil
 }

--- a/services/processor-service/repository/processor-repository.go
+++ b/services/processor-service/repository/processor-repository.go
@@ -35,7 +35,7 @@ func (r *ProcessorRepository) GetOutboxMessages(ctx context.Context, published b
 	var outboxMessages []*processorv1.OutboxMessage
 
 	var eventId, eventType string
-	var payload []byte
+	var payload string
 	var isPublished bool
 
 	for iter.Scan(&eventId, &eventType, &payload, &isPublished) {

--- a/services/user-service/auth/jwt.go
+++ b/services/user-service/auth/jwt.go
@@ -33,7 +33,7 @@ func GenerateJWTToken(userID int64, email string, username string, fullName stri
 		Username: username,
 		FullName: fullName,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(60 * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			NotBefore: jwt.NewNumericDate(time.Now()),
 			Issuer:    "threads-go-backend",

--- a/services/user-service/cmd/client/main.go
+++ b/services/user-service/cmd/client/main.go
@@ -42,7 +42,7 @@ func main() {
 		userServiceUrl,
 	)
 	req := connect.NewRequest(&userv1.FollowUserRequest{
-		FollowingId: 144603701179338358,
+		FollowingId: 144603817143455350,
 	})
 
 	req.Header().Set("Authorization", "Bearer "+os.Getenv("ACCESS_TOKEN"))

--- a/services/user-service/controller/user-controller.go
+++ b/services/user-service/controller/user-controller.go
@@ -21,7 +21,6 @@ type UserController struct {
 	store    auth.RefreshTokenStore
 }
 
-// NewUserController creates a new UserController with the provided user repository and refresh token store.
 func NewUserController(userRepo *repository.UserRepository, store auth.RefreshTokenStore) *UserController {
 	return &UserController{
 		userRepo: userRepo,
@@ -42,12 +41,12 @@ func (c *UserController) CreateUser(
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Msg.Password), bcrypt.DefaultCost)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to hash password"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to hash password: %w", err))
 	}
 
 	userId, err := snowflake.GenerateID()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to generate id"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to generate user ID: %w", err))
 	}
 
 	user := &userv1.User{
@@ -66,9 +65,7 @@ func (c *UserController) CreateUser(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create user: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.CreateUserResponse{
-		User: user,
-	}), nil
+	return connect.NewResponse(&userv1.CreateUserResponse{User: user}), nil
 }
 
 // ---------------- Login User ------------------
@@ -92,12 +89,12 @@ func (c *UserController) LoginUser(
 
 	accessToken, err := auth.GenerateJWTToken(user.Id, user.Email, user.Username, user.FullName)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to generate token"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to generate token: %w", err))
 	}
 
 	refreshToken, err := c.store.CreateOrGetRefreshToken(ctx, user.Id)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to generate refresh token"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to generate refresh token: %w", err))
 	}
 
 	return connect.NewResponse(&userv1.LoginUserResponse{
@@ -132,9 +129,7 @@ func (c *UserController) UpdateUser(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to update user: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.UpdateUserResponse{
-		User: user,
-	}), nil
+	return connect.NewResponse(&userv1.UpdateUserResponse{User: user}), nil
 }
 
 // ---------------- Delete User ------------------
@@ -160,9 +155,7 @@ func (c *UserController) DeleteUser(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete user: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.DeleteUserResponse{
-		Success: true,
-	}), nil
+	return connect.NewResponse(&userv1.DeleteUserResponse{Success: true}), nil
 }
 
 // ---------------- Get User By ID ------------------
@@ -180,9 +173,7 @@ func (c *UserController) GetUserByID(
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get user: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.GetUserByIDResponse{
-		User: user,
-	}), nil
+	return connect.NewResponse(&userv1.GetUserByIDResponse{User: user}), nil
 }
 
 // ---------------- List Users ------------------
@@ -212,25 +203,20 @@ func (c *UserController) FollowUser(
 	req *connect.Request[userv1.FollowUserRequest],
 ) (*connect.Response[userv1.FollowUserResponse], error) {
 
-	// Validate target user
 	if req.Msg.FollowingId == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid request"))
 	}
 
-	// Get authenticated user
-	userFromCtx, err := auth.GetUserFromContext(ctx)
+	user, err := auth.GetUserFromContext(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
 	}
 
-	if userFromCtx.Id == req.Msg.FollowingId {
+	if user.Id == req.Msg.FollowingId {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot follow yourself"))
 	}
 
-	// Current timestamp
-	now := time.Now()
-
-	if err := c.userRepo.SaveFollowRelationAndEmitEvent(ctx, userFromCtx.Id, req.Msg.FollowingId, now); err != nil {
+	if err := c.userRepo.SaveFollowRelationAndEmitEvent(ctx, user.Id, req.Msg.FollowingId, time.Now()); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to follow user: %w", err))
 	}
 
@@ -247,16 +233,16 @@ func (c *UserController) UnfollowUser(
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid request"))
 	}
 
-	userFromCtx, err := auth.GetUserFromContext(ctx)
+	user, err := auth.GetUserFromContext(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
 	}
 
-	if userFromCtx.Id == req.Msg.FollowingId {
+	if user.Id == req.Msg.FollowingId {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot unfollow yourself"))
 	}
 
-	if err := c.userRepo.UnfollowUser(ctx, userFromCtx.Id, req.Msg.FollowingId, time.Now()); err != nil {
+	if err := c.userRepo.UnfollowUser(ctx, user.Id, req.Msg.FollowingId, time.Now()); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to unfollow user: %w", err))
 	}
 
@@ -288,16 +274,16 @@ func (c *UserController) RefreshToken(
 
 	accessToken, err := auth.GenerateJWTToken(user.Id, user.Email, user.Username, user.FullName)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to generate access token"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to generate access token: %w", err))
 	}
-	// Rotate: delete old token
+
 	if err := c.store.DeleteRefreshToken(ctx, req.Msg.UserId); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to delete old refresh token: %w", err))
 	}
 
 	newRefreshToken, err := c.store.CreateOrGetRefreshToken(ctx, req.Msg.UserId)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to create refresh token"))
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to create refresh token: %w", err))
 	}
 
 	return connect.NewResponse(&userv1.RefreshTokenResponse{
@@ -306,77 +292,114 @@ func (c *UserController) RefreshToken(
 	}), nil
 }
 
+// ---------------- Increment Follow Counts ------------------
 func (c *UserController) IncrementFollowingAndFollowerCount(
 	ctx context.Context,
 	req *connect.Request[userv1.IncrementFollowingAndFollowerCountRequest],
 ) (*connect.Response[userv1.IncrementFollowingAndFollowerCountResponse], error) {
-	event := req.Msg.GetFollowedEvent()
 
-	if event == nil || event.FollowedAt == nil || event.UserId == 0 || event.FollowingId == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("followed event is missing or invalid"))
+	if req.Msg.FollowedEvent.FollowingId == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid following ID"))
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	user, err := auth.GetUserFromContext(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
 
-	// Increment following count (for the user performing the follow)
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Increment sender's following count
 	g.Go(func() error {
-		if err := c.userRepo.IncrementFollowingCount(ctx, event.UserId); err != nil {
-			return fmt.Errorf("failed to increment following count: %w", err)
-		}
-		return nil
+		return c.userRepo.IncrementFollowingCount(gctx, user.Id)
 	})
 
-	// Increment follower count (for the user being followed)
+	// Increment recipient's follower count
 	g.Go(func() error {
-		if err := c.userRepo.IncrementFollowerCount(ctx, event.FollowingId); err != nil {
-			return fmt.Errorf("failed to increment follower count: %w", err)
-		}
-		return nil
+		return c.userRepo.IncrementFollowerCount(gctx, req.Msg.FollowedEvent.FollowingId)
 	})
 
-	// Wait for both goroutines
 	if err := g.Wait(); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to increment follow counts: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.IncrementFollowingAndFollowerCountResponse{
-		Incremented: true,
-	}), nil
-
+	return connect.NewResponse(&userv1.IncrementFollowingAndFollowerCountResponse{Incremented: true}), nil
 }
-func (c *UserController) DecrementFollowingAndFollowerCount(ctx context.Context,
+
+// ---------------- Decrement Follow Counts ------------------
+func (c *UserController) DecrementFollowingAndFollowerCount(
+	ctx context.Context,
 	req *connect.Request[userv1.DecrementFollowingAndFollowerCountRequest],
 ) (*connect.Response[userv1.DecrementFollowingAndFollowerCountResponse], error) {
-	event := req.Msg.GetUnfollowedEvent()
 
-	if event == nil || event.UnfollowedAt == nil || event.UserId == 0 || event.FollowingId == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("unfollowed event is missing or invalid"))
+	if req.Msg.UnfollowedEvent.FollowingId == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid following ID"))
 	}
-	g, ctx := errgroup.WithContext(ctx)
 
-	// Decrement following count (for the user performing the unfollow)
+	user, err := auth.GetUserFromContext(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	// Decrement sender's following count
 	g.Go(func() error {
-		if err := c.userRepo.DecrementFollowingCount(ctx, event.UserId); err != nil {
-			return fmt.Errorf("failed to decrement following count: %w", err)
-		}
-		return nil
+		return c.userRepo.DecrementFollowingCount(gctx, user.Id)
 	})
 
-	// Decrement follower count (for the user being unfollowed)
+	// Decrement recipient's follower count
 	g.Go(func() error {
-		if err := c.userRepo.DecrementFollowerCount(ctx, event.FollowingId); err != nil {
-			return fmt.Errorf("failed to decrement follower count: %w", err)
-		}
-		return nil
+		return c.userRepo.DecrementFollowerCount(gctx, req.Msg.UnfollowedEvent.FollowingId)
 	})
 
-	// Wait for both goroutines
 	if err := g.Wait(); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to decrement follow counts: %w", err))
 	}
 
-	return connect.NewResponse(&userv1.DecrementFollowingAndFollowerCountResponse{
-		Decremented: true,
-	}), nil
+	return connect.NewResponse(&userv1.DecrementFollowingAndFollowerCountResponse{Decremented: true}), nil
+}
 
+// ---------------- Cache Follow Relation ------------------
+func (c *UserController) FollowUserCached(
+	ctx context.Context,
+	req *connect.Request[userv1.FollowUserCachedRequest],
+) (*connect.Response[userv1.FollowUserCachedResponse], error) {
+
+	if req.Msg.FollowingId == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid following ID"))
+	}
+
+	user, err := auth.GetUserFromContext(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
+
+	if err := c.userRepo.FollowUserCached(ctx, user.Id, req.Msg.FollowingId); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to cache follow: %w", err))
+	}
+
+	return connect.NewResponse(&userv1.FollowUserCachedResponse{Success: true}), nil
+}
+
+// ---------------- Cache Unfollow Relation ------------------
+func (c *UserController) UnfollowUserCached(
+	ctx context.Context,
+	req *connect.Request[userv1.UnfollowUserCachedRequest],
+) (*connect.Response[userv1.UnfollowUserCachedResponse], error) {
+
+	if req.Msg.FollowingId == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid following ID"))
+	}
+
+	user, err := auth.GetUserFromContext(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
+	}
+
+	if err := c.userRepo.UnfollowUserCached(ctx, user.Id, req.Msg.FollowingId); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to cache unfollow: %w", err))
+	}
+
+	return connect.NewResponse(&userv1.UnfollowUserCachedResponse{Success: true}), nil
 }

--- a/shared/queue/kafka.go
+++ b/shared/queue/kafka.go
@@ -55,7 +55,7 @@ func NewKafkaReader(cfg Config) *kafka.Reader {
 		Topic:            cfg.Topic,
 		MinBytes:         10e3, // 10KB
 		MaxBytes:         10e6, // 10MB
-		StartOffset:      kafka.FirstOffset,
+		StartOffset:      kafka.LastOffset,
 		CommitInterval:   time.Second,
 		Dialer:           newDialer(cfg),
 		SessionTimeout:   45 * time.Second, // Matches session.timeout.ms


### PR DESCRIPTION
- Changed the Payload field type in OutboxMessage from []byte to string for better compatibility.
- Updated OutboxEvent in user.proto and user.pb.go to directly include event_id, event_type, payload, and published fields instead of using OutboxMessage.
- Implemented FollowUserCached and UnfollowUserCached methods in UserController and UserRepository to cache follow/unfollow actions.
- Enhanced user service to handle follow/unfollow events with caching logic and improved error handling.
- Updated Kafka message processing to utilize the new event structure and caching mechanisms.