### PR TITLE
feat: add CreatePostIndexedByUser and InitializePostEngagements RPCs …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 kafka.properties
+todo.md

--- a/gen/posts/v1/post.pb.go
+++ b/gen/posts/v1/post.pb.go
@@ -201,6 +201,182 @@ func (x *OutboxEvent) GetPublished() bool {
 	return false
 }
 
+type CreatePostIndexedByUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Post          *Post                  `protobuf:"bytes,1,opt,name=post,proto3" json:"post,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreatePostIndexedByUserRequest) Reset() {
+	*x = CreatePostIndexedByUserRequest{}
+	mi := &file_posts_v1_post_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreatePostIndexedByUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreatePostIndexedByUserRequest) ProtoMessage() {}
+
+func (x *CreatePostIndexedByUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_posts_v1_post_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreatePostIndexedByUserRequest.ProtoReflect.Descriptor instead.
+func (*CreatePostIndexedByUserRequest) Descriptor() ([]byte, []int) {
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CreatePostIndexedByUserRequest) GetPost() *Post {
+	if x != nil {
+		return x.Post
+	}
+	return nil
+}
+
+type CreatePostIndexedByUserResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreatePostIndexedByUserResponse) Reset() {
+	*x = CreatePostIndexedByUserResponse{}
+	mi := &file_posts_v1_post_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreatePostIndexedByUserResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreatePostIndexedByUserResponse) ProtoMessage() {}
+
+func (x *CreatePostIndexedByUserResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_posts_v1_post_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreatePostIndexedByUserResponse.ProtoReflect.Descriptor instead.
+func (*CreatePostIndexedByUserResponse) Descriptor() ([]byte, []int) {
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *CreatePostIndexedByUserResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+type InitializePostEngagementsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PostId        int64                  `protobuf:"varint,1,opt,name=post_id,json=postId,proto3" json:"post_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InitializePostEngagementsRequest) Reset() {
+	*x = InitializePostEngagementsRequest{}
+	mi := &file_posts_v1_post_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InitializePostEngagementsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InitializePostEngagementsRequest) ProtoMessage() {}
+
+func (x *InitializePostEngagementsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_posts_v1_post_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InitializePostEngagementsRequest.ProtoReflect.Descriptor instead.
+func (*InitializePostEngagementsRequest) Descriptor() ([]byte, []int) {
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *InitializePostEngagementsRequest) GetPostId() int64 {
+	if x != nil {
+		return x.PostId
+	}
+	return 0
+}
+
+type InitializePostEngagementsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	True          bool                   `protobuf:"varint,1,opt,name=true,proto3" json:"true,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InitializePostEngagementsResponse) Reset() {
+	*x = InitializePostEngagementsResponse{}
+	mi := &file_posts_v1_post_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InitializePostEngagementsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InitializePostEngagementsResponse) ProtoMessage() {}
+
+func (x *InitializePostEngagementsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_posts_v1_post_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InitializePostEngagementsResponse.ProtoReflect.Descriptor instead.
+func (*InitializePostEngagementsResponse) Descriptor() ([]byte, []int) {
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *InitializePostEngagementsResponse) GetTrue() bool {
+	if x != nil {
+		return x.True
+	}
+	return false
+}
+
 type CreatePostRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Content       string                 `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
@@ -212,7 +388,7 @@ type CreatePostRequest struct {
 
 func (x *CreatePostRequest) Reset() {
 	*x = CreatePostRequest{}
-	mi := &file_posts_v1_post_proto_msgTypes[2]
+	mi := &file_posts_v1_post_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -224,7 +400,7 @@ func (x *CreatePostRequest) String() string {
 func (*CreatePostRequest) ProtoMessage() {}
 
 func (x *CreatePostRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[2]
+	mi := &file_posts_v1_post_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -237,7 +413,7 @@ func (x *CreatePostRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePostRequest.ProtoReflect.Descriptor instead.
 func (*CreatePostRequest) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{2}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CreatePostRequest) GetContent() string {
@@ -270,7 +446,7 @@ type CreatePostResponse struct {
 
 func (x *CreatePostResponse) Reset() {
 	*x = CreatePostResponse{}
-	mi := &file_posts_v1_post_proto_msgTypes[3]
+	mi := &file_posts_v1_post_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -282,7 +458,7 @@ func (x *CreatePostResponse) String() string {
 func (*CreatePostResponse) ProtoMessage() {}
 
 func (x *CreatePostResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[3]
+	mi := &file_posts_v1_post_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -295,7 +471,7 @@ func (x *CreatePostResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreatePostResponse.ProtoReflect.Descriptor instead.
 func (*CreatePostResponse) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{3}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreatePostResponse) GetPost() *Post {
@@ -314,7 +490,7 @@ type GetPostRequest struct {
 
 func (x *GetPostRequest) Reset() {
 	*x = GetPostRequest{}
-	mi := &file_posts_v1_post_proto_msgTypes[4]
+	mi := &file_posts_v1_post_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -326,7 +502,7 @@ func (x *GetPostRequest) String() string {
 func (*GetPostRequest) ProtoMessage() {}
 
 func (x *GetPostRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[4]
+	mi := &file_posts_v1_post_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -339,7 +515,7 @@ func (x *GetPostRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPostRequest.ProtoReflect.Descriptor instead.
 func (*GetPostRequest) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{4}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetPostRequest) GetPostId() int64 {
@@ -358,7 +534,7 @@ type GetPostResponse struct {
 
 func (x *GetPostResponse) Reset() {
 	*x = GetPostResponse{}
-	mi := &file_posts_v1_post_proto_msgTypes[5]
+	mi := &file_posts_v1_post_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -370,7 +546,7 @@ func (x *GetPostResponse) String() string {
 func (*GetPostResponse) ProtoMessage() {}
 
 func (x *GetPostResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[5]
+	mi := &file_posts_v1_post_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -383,7 +559,7 @@ func (x *GetPostResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPostResponse.ProtoReflect.Descriptor instead.
 func (*GetPostResponse) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{5}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetPostResponse) GetPost() *Post {
@@ -404,7 +580,7 @@ type ListPostsByUserRequest struct {
 
 func (x *ListPostsByUserRequest) Reset() {
 	*x = ListPostsByUserRequest{}
-	mi := &file_posts_v1_post_proto_msgTypes[6]
+	mi := &file_posts_v1_post_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -416,7 +592,7 @@ func (x *ListPostsByUserRequest) String() string {
 func (*ListPostsByUserRequest) ProtoMessage() {}
 
 func (x *ListPostsByUserRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[6]
+	mi := &file_posts_v1_post_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -429,7 +605,7 @@ func (x *ListPostsByUserRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPostsByUserRequest.ProtoReflect.Descriptor instead.
 func (*ListPostsByUserRequest) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{6}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListPostsByUserRequest) GetUserId() int64 {
@@ -463,7 +639,7 @@ type ListPostsByUserResponse struct {
 
 func (x *ListPostsByUserResponse) Reset() {
 	*x = ListPostsByUserResponse{}
-	mi := &file_posts_v1_post_proto_msgTypes[7]
+	mi := &file_posts_v1_post_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -475,7 +651,7 @@ func (x *ListPostsByUserResponse) String() string {
 func (*ListPostsByUserResponse) ProtoMessage() {}
 
 func (x *ListPostsByUserResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[7]
+	mi := &file_posts_v1_post_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,7 +664,7 @@ func (x *ListPostsByUserResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPostsByUserResponse.ProtoReflect.Descriptor instead.
 func (*ListPostsByUserResponse) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{7}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListPostsByUserResponse) GetPosts() []*Post {
@@ -514,7 +690,7 @@ type DeletePostRequest struct {
 
 func (x *DeletePostRequest) Reset() {
 	*x = DeletePostRequest{}
-	mi := &file_posts_v1_post_proto_msgTypes[8]
+	mi := &file_posts_v1_post_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -526,7 +702,7 @@ func (x *DeletePostRequest) String() string {
 func (*DeletePostRequest) ProtoMessage() {}
 
 func (x *DeletePostRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[8]
+	mi := &file_posts_v1_post_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -539,7 +715,7 @@ func (x *DeletePostRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePostRequest.ProtoReflect.Descriptor instead.
 func (*DeletePostRequest) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{8}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DeletePostRequest) GetPostId() int64 {
@@ -558,7 +734,7 @@ type DeletePostResponse struct {
 
 func (x *DeletePostResponse) Reset() {
 	*x = DeletePostResponse{}
-	mi := &file_posts_v1_post_proto_msgTypes[9]
+	mi := &file_posts_v1_post_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -570,7 +746,7 @@ func (x *DeletePostResponse) String() string {
 func (*DeletePostResponse) ProtoMessage() {}
 
 func (x *DeletePostResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_posts_v1_post_proto_msgTypes[9]
+	mi := &file_posts_v1_post_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -583,7 +759,7 @@ func (x *DeletePostResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePostResponse.ProtoReflect.Descriptor instead.
 func (*DeletePostResponse) Descriptor() ([]byte, []int) {
-	return file_posts_v1_post_proto_rawDescGZIP(), []int{9}
+	return file_posts_v1_post_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DeletePostResponse) GetSuccess() bool {
@@ -617,7 +793,15 @@ const file_posts_v1_post_proto_rawDesc = "" +
 	"\n" +
 	"event_type\x18\x02 \x01(\tR\teventType\x12\x18\n" +
 	"\apayload\x18\x03 \x01(\tR\apayload\x12\x1c\n" +
-	"\tpublished\x18\x04 \x01(\bR\tpublished\"c\n" +
+	"\tpublished\x18\x04 \x01(\bR\tpublished\"D\n" +
+	"\x1eCreatePostIndexedByUserRequest\x12\"\n" +
+	"\x04post\x18\x01 \x01(\v2\x0e.posts.v1.PostR\x04post\";\n" +
+	"\x1fCreatePostIndexedByUserResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\";\n" +
+	" InitializePostEngagementsRequest\x12\x17\n" +
+	"\apost_id\x18\x01 \x01(\x03R\x06postId\"7\n" +
+	"!InitializePostEngagementsResponse\x12\x12\n" +
+	"\x04true\x18\x01 \x01(\bR\x04true\"c\n" +
 	"\x11CreatePostRequest\x12\x18\n" +
 	"\acontent\x18\x01 \x01(\tR\acontent\x12\x1b\n" +
 	"\timage_url\x18\x02 \x01(\tR\bimageUrl\x12\x17\n" +
@@ -638,14 +822,16 @@ const file_posts_v1_post_proto_rawDesc = "" +
 	"\x11DeletePostRequest\x12\x17\n" +
 	"\apost_id\x18\x01 \x01(\x03R\x06postId\".\n" +
 	"\x12DeletePostResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess2\xb7\x02\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess2\x9d\x04\n" +
 	"\vPostService\x12G\n" +
 	"\n" +
 	"CreatePost\x12\x1b.posts.v1.CreatePostRequest\x1a\x1c.posts.v1.CreatePostResponse\x12>\n" +
 	"\aGetPost\x12\x18.posts.v1.GetPostRequest\x1a\x19.posts.v1.GetPostResponse\x12V\n" +
 	"\x0fListPostsByUser\x12 .posts.v1.ListPostsByUserRequest\x1a!.posts.v1.ListPostsByUserResponse\x12G\n" +
 	"\n" +
-	"DeletePost\x12\x1b.posts.v1.DeletePostRequest\x1a\x1c.posts.v1.DeletePostResponseB\x9b\x01\n" +
+	"DeletePost\x12\x1b.posts.v1.DeletePostRequest\x1a\x1c.posts.v1.DeletePostResponse\x12n\n" +
+	"\x17CreatePostIndexedByUser\x12(.posts.v1.CreatePostIndexedByUserRequest\x1a).posts.v1.CreatePostIndexedByUserResponse\x12t\n" +
+	"\x19InitializePostEngagements\x12*.posts.v1.InitializePostEngagementsRequest\x1a+.posts.v1.InitializePostEngagementsResponseB\x9b\x01\n" +
 	"\fcom.posts.v1B\tPostProtoP\x01Z?github.com/yaninyzwitty/threads-go-backend/gen/posts/v1;postsv1\xa2\x02\x03PXX\xaa\x02\bPosts.V1\xca\x02\bPosts\\V1\xe2\x02\x14Posts\\V1\\GPBMetadata\xea\x02\tPosts::V1b\x06proto3"
 
 var (
@@ -660,38 +846,47 @@ func file_posts_v1_post_proto_rawDescGZIP() []byte {
 	return file_posts_v1_post_proto_rawDescData
 }
 
-var file_posts_v1_post_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_posts_v1_post_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_posts_v1_post_proto_goTypes = []any{
-	(*Post)(nil),                    // 0: posts.v1.Post
-	(*OutboxEvent)(nil),             // 1: posts.v1.OutboxEvent
-	(*CreatePostRequest)(nil),       // 2: posts.v1.CreatePostRequest
-	(*CreatePostResponse)(nil),      // 3: posts.v1.CreatePostResponse
-	(*GetPostRequest)(nil),          // 4: posts.v1.GetPostRequest
-	(*GetPostResponse)(nil),         // 5: posts.v1.GetPostResponse
-	(*ListPostsByUserRequest)(nil),  // 6: posts.v1.ListPostsByUserRequest
-	(*ListPostsByUserResponse)(nil), // 7: posts.v1.ListPostsByUserResponse
-	(*DeletePostRequest)(nil),       // 8: posts.v1.DeletePostRequest
-	(*DeletePostResponse)(nil),      // 9: posts.v1.DeletePostResponse
-	(*timestamppb.Timestamp)(nil),   // 10: google.protobuf.Timestamp
+	(*Post)(nil),                              // 0: posts.v1.Post
+	(*OutboxEvent)(nil),                       // 1: posts.v1.OutboxEvent
+	(*CreatePostIndexedByUserRequest)(nil),    // 2: posts.v1.CreatePostIndexedByUserRequest
+	(*CreatePostIndexedByUserResponse)(nil),   // 3: posts.v1.CreatePostIndexedByUserResponse
+	(*InitializePostEngagementsRequest)(nil),  // 4: posts.v1.InitializePostEngagementsRequest
+	(*InitializePostEngagementsResponse)(nil), // 5: posts.v1.InitializePostEngagementsResponse
+	(*CreatePostRequest)(nil),                 // 6: posts.v1.CreatePostRequest
+	(*CreatePostResponse)(nil),                // 7: posts.v1.CreatePostResponse
+	(*GetPostRequest)(nil),                    // 8: posts.v1.GetPostRequest
+	(*GetPostResponse)(nil),                   // 9: posts.v1.GetPostResponse
+	(*ListPostsByUserRequest)(nil),            // 10: posts.v1.ListPostsByUserRequest
+	(*ListPostsByUserResponse)(nil),           // 11: posts.v1.ListPostsByUserResponse
+	(*DeletePostRequest)(nil),                 // 12: posts.v1.DeletePostRequest
+	(*DeletePostResponse)(nil),                // 13: posts.v1.DeletePostResponse
+	(*timestamppb.Timestamp)(nil),             // 14: google.protobuf.Timestamp
 }
 var file_posts_v1_post_proto_depIdxs = []int32{
-	10, // 0: posts.v1.Post.created_at:type_name -> google.protobuf.Timestamp
-	0,  // 1: posts.v1.CreatePostResponse.post:type_name -> posts.v1.Post
-	0,  // 2: posts.v1.GetPostResponse.post:type_name -> posts.v1.Post
-	0,  // 3: posts.v1.ListPostsByUserResponse.posts:type_name -> posts.v1.Post
-	2,  // 4: posts.v1.PostService.CreatePost:input_type -> posts.v1.CreatePostRequest
-	4,  // 5: posts.v1.PostService.GetPost:input_type -> posts.v1.GetPostRequest
-	6,  // 6: posts.v1.PostService.ListPostsByUser:input_type -> posts.v1.ListPostsByUserRequest
-	8,  // 7: posts.v1.PostService.DeletePost:input_type -> posts.v1.DeletePostRequest
-	3,  // 8: posts.v1.PostService.CreatePost:output_type -> posts.v1.CreatePostResponse
-	5,  // 9: posts.v1.PostService.GetPost:output_type -> posts.v1.GetPostResponse
-	7,  // 10: posts.v1.PostService.ListPostsByUser:output_type -> posts.v1.ListPostsByUserResponse
-	9,  // 11: posts.v1.PostService.DeletePost:output_type -> posts.v1.DeletePostResponse
-	8,  // [8:12] is the sub-list for method output_type
-	4,  // [4:8] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	14, // 0: posts.v1.Post.created_at:type_name -> google.protobuf.Timestamp
+	0,  // 1: posts.v1.CreatePostIndexedByUserRequest.post:type_name -> posts.v1.Post
+	0,  // 2: posts.v1.CreatePostResponse.post:type_name -> posts.v1.Post
+	0,  // 3: posts.v1.GetPostResponse.post:type_name -> posts.v1.Post
+	0,  // 4: posts.v1.ListPostsByUserResponse.posts:type_name -> posts.v1.Post
+	6,  // 5: posts.v1.PostService.CreatePost:input_type -> posts.v1.CreatePostRequest
+	8,  // 6: posts.v1.PostService.GetPost:input_type -> posts.v1.GetPostRequest
+	10, // 7: posts.v1.PostService.ListPostsByUser:input_type -> posts.v1.ListPostsByUserRequest
+	12, // 8: posts.v1.PostService.DeletePost:input_type -> posts.v1.DeletePostRequest
+	2,  // 9: posts.v1.PostService.CreatePostIndexedByUser:input_type -> posts.v1.CreatePostIndexedByUserRequest
+	4,  // 10: posts.v1.PostService.InitializePostEngagements:input_type -> posts.v1.InitializePostEngagementsRequest
+	7,  // 11: posts.v1.PostService.CreatePost:output_type -> posts.v1.CreatePostResponse
+	9,  // 12: posts.v1.PostService.GetPost:output_type -> posts.v1.GetPostResponse
+	11, // 13: posts.v1.PostService.ListPostsByUser:output_type -> posts.v1.ListPostsByUserResponse
+	13, // 14: posts.v1.PostService.DeletePost:output_type -> posts.v1.DeletePostResponse
+	3,  // 15: posts.v1.PostService.CreatePostIndexedByUser:output_type -> posts.v1.CreatePostIndexedByUserResponse
+	5,  // 16: posts.v1.PostService.InitializePostEngagements:output_type -> posts.v1.InitializePostEngagementsResponse
+	11, // [11:17] is the sub-list for method output_type
+	5,  // [5:11] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_posts_v1_post_proto_init() }
@@ -705,7 +900,7 @@ func file_posts_v1_post_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_posts_v1_post_proto_rawDesc), len(file_posts_v1_post_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/posts/v1/postsv1connect/post.connect.go
+++ b/gen/posts/v1/postsv1connect/post.connect.go
@@ -42,6 +42,12 @@ const (
 	PostServiceListPostsByUserProcedure = "/posts.v1.PostService/ListPostsByUser"
 	// PostServiceDeletePostProcedure is the fully-qualified name of the PostService's DeletePost RPC.
 	PostServiceDeletePostProcedure = "/posts.v1.PostService/DeletePost"
+	// PostServiceCreatePostIndexedByUserProcedure is the fully-qualified name of the PostService's
+	// CreatePostIndexedByUser RPC.
+	PostServiceCreatePostIndexedByUserProcedure = "/posts.v1.PostService/CreatePostIndexedByUser"
+	// PostServiceInitializePostEngagementsProcedure is the fully-qualified name of the PostService's
+	// InitializePostEngagements RPC.
+	PostServiceInitializePostEngagementsProcedure = "/posts.v1.PostService/InitializePostEngagements"
 )
 
 // PostServiceClient is a client for the posts.v1.PostService service.
@@ -50,6 +56,8 @@ type PostServiceClient interface {
 	GetPost(context.Context, *connect.Request[v1.GetPostRequest]) (*connect.Response[v1.GetPostResponse], error)
 	ListPostsByUser(context.Context, *connect.Request[v1.ListPostsByUserRequest]) (*connect.Response[v1.ListPostsByUserResponse], error)
 	DeletePost(context.Context, *connect.Request[v1.DeletePostRequest]) (*connect.Response[v1.DeletePostResponse], error)
+	CreatePostIndexedByUser(context.Context, *connect.Request[v1.CreatePostIndexedByUserRequest]) (*connect.Response[v1.CreatePostIndexedByUserResponse], error)
+	InitializePostEngagements(context.Context, *connect.Request[v1.InitializePostEngagementsRequest]) (*connect.Response[v1.InitializePostEngagementsResponse], error)
 }
 
 // NewPostServiceClient constructs a client for the posts.v1.PostService service. By default, it
@@ -87,15 +95,29 @@ func NewPostServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 			connect.WithSchema(postServiceMethods.ByName("DeletePost")),
 			connect.WithClientOptions(opts...),
 		),
+		createPostIndexedByUser: connect.NewClient[v1.CreatePostIndexedByUserRequest, v1.CreatePostIndexedByUserResponse](
+			httpClient,
+			baseURL+PostServiceCreatePostIndexedByUserProcedure,
+			connect.WithSchema(postServiceMethods.ByName("CreatePostIndexedByUser")),
+			connect.WithClientOptions(opts...),
+		),
+		initializePostEngagements: connect.NewClient[v1.InitializePostEngagementsRequest, v1.InitializePostEngagementsResponse](
+			httpClient,
+			baseURL+PostServiceInitializePostEngagementsProcedure,
+			connect.WithSchema(postServiceMethods.ByName("InitializePostEngagements")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // postServiceClient implements PostServiceClient.
 type postServiceClient struct {
-	createPost      *connect.Client[v1.CreatePostRequest, v1.CreatePostResponse]
-	getPost         *connect.Client[v1.GetPostRequest, v1.GetPostResponse]
-	listPostsByUser *connect.Client[v1.ListPostsByUserRequest, v1.ListPostsByUserResponse]
-	deletePost      *connect.Client[v1.DeletePostRequest, v1.DeletePostResponse]
+	createPost                *connect.Client[v1.CreatePostRequest, v1.CreatePostResponse]
+	getPost                   *connect.Client[v1.GetPostRequest, v1.GetPostResponse]
+	listPostsByUser           *connect.Client[v1.ListPostsByUserRequest, v1.ListPostsByUserResponse]
+	deletePost                *connect.Client[v1.DeletePostRequest, v1.DeletePostResponse]
+	createPostIndexedByUser   *connect.Client[v1.CreatePostIndexedByUserRequest, v1.CreatePostIndexedByUserResponse]
+	initializePostEngagements *connect.Client[v1.InitializePostEngagementsRequest, v1.InitializePostEngagementsResponse]
 }
 
 // CreatePost calls posts.v1.PostService.CreatePost.
@@ -118,12 +140,24 @@ func (c *postServiceClient) DeletePost(ctx context.Context, req *connect.Request
 	return c.deletePost.CallUnary(ctx, req)
 }
 
+// CreatePostIndexedByUser calls posts.v1.PostService.CreatePostIndexedByUser.
+func (c *postServiceClient) CreatePostIndexedByUser(ctx context.Context, req *connect.Request[v1.CreatePostIndexedByUserRequest]) (*connect.Response[v1.CreatePostIndexedByUserResponse], error) {
+	return c.createPostIndexedByUser.CallUnary(ctx, req)
+}
+
+// InitializePostEngagements calls posts.v1.PostService.InitializePostEngagements.
+func (c *postServiceClient) InitializePostEngagements(ctx context.Context, req *connect.Request[v1.InitializePostEngagementsRequest]) (*connect.Response[v1.InitializePostEngagementsResponse], error) {
+	return c.initializePostEngagements.CallUnary(ctx, req)
+}
+
 // PostServiceHandler is an implementation of the posts.v1.PostService service.
 type PostServiceHandler interface {
 	CreatePost(context.Context, *connect.Request[v1.CreatePostRequest]) (*connect.Response[v1.CreatePostResponse], error)
 	GetPost(context.Context, *connect.Request[v1.GetPostRequest]) (*connect.Response[v1.GetPostResponse], error)
 	ListPostsByUser(context.Context, *connect.Request[v1.ListPostsByUserRequest]) (*connect.Response[v1.ListPostsByUserResponse], error)
 	DeletePost(context.Context, *connect.Request[v1.DeletePostRequest]) (*connect.Response[v1.DeletePostResponse], error)
+	CreatePostIndexedByUser(context.Context, *connect.Request[v1.CreatePostIndexedByUserRequest]) (*connect.Response[v1.CreatePostIndexedByUserResponse], error)
+	InitializePostEngagements(context.Context, *connect.Request[v1.InitializePostEngagementsRequest]) (*connect.Response[v1.InitializePostEngagementsResponse], error)
 }
 
 // NewPostServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -157,6 +191,18 @@ func NewPostServiceHandler(svc PostServiceHandler, opts ...connect.HandlerOption
 		connect.WithSchema(postServiceMethods.ByName("DeletePost")),
 		connect.WithHandlerOptions(opts...),
 	)
+	postServiceCreatePostIndexedByUserHandler := connect.NewUnaryHandler(
+		PostServiceCreatePostIndexedByUserProcedure,
+		svc.CreatePostIndexedByUser,
+		connect.WithSchema(postServiceMethods.ByName("CreatePostIndexedByUser")),
+		connect.WithHandlerOptions(opts...),
+	)
+	postServiceInitializePostEngagementsHandler := connect.NewUnaryHandler(
+		PostServiceInitializePostEngagementsProcedure,
+		svc.InitializePostEngagements,
+		connect.WithSchema(postServiceMethods.ByName("InitializePostEngagements")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/posts.v1.PostService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PostServiceCreatePostProcedure:
@@ -167,6 +213,10 @@ func NewPostServiceHandler(svc PostServiceHandler, opts ...connect.HandlerOption
 			postServiceListPostsByUserHandler.ServeHTTP(w, r)
 		case PostServiceDeletePostProcedure:
 			postServiceDeletePostHandler.ServeHTTP(w, r)
+		case PostServiceCreatePostIndexedByUserProcedure:
+			postServiceCreatePostIndexedByUserHandler.ServeHTTP(w, r)
+		case PostServiceInitializePostEngagementsProcedure:
+			postServiceInitializePostEngagementsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -190,4 +240,12 @@ func (UnimplementedPostServiceHandler) ListPostsByUser(context.Context, *connect
 
 func (UnimplementedPostServiceHandler) DeletePost(context.Context, *connect.Request[v1.DeletePostRequest]) (*connect.Response[v1.DeletePostResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("posts.v1.PostService.DeletePost is not implemented"))
+}
+
+func (UnimplementedPostServiceHandler) CreatePostIndexedByUser(context.Context, *connect.Request[v1.CreatePostIndexedByUserRequest]) (*connect.Response[v1.CreatePostIndexedByUserResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("posts.v1.PostService.CreatePostIndexedByUser is not implemented"))
+}
+
+func (UnimplementedPostServiceHandler) InitializePostEngagements(context.Context, *connect.Request[v1.InitializePostEngagementsRequest]) (*connect.Response[v1.InitializePostEngagementsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("posts.v1.PostService.InitializePostEngagements is not implemented"))
 }

--- a/proto/posts/v1/post.proto
+++ b/proto/posts/v1/post.proto
@@ -28,12 +28,30 @@ message OutboxEvent {
   bool published = 4;
 }
 
+message CreatePostIndexedByUserRequest {
+  Post post = 1;
+}
+
+message CreatePostIndexedByUserResponse {
+  bool success = 1;
+}
+
+message InitializePostEngagementsRequest {
+  int64 post_id = 1;
+
+}
+
+message InitializePostEngagementsResponse {
+  bool true = 1;
+}
 // Service definition
 service PostService {
   rpc CreatePost(CreatePostRequest) returns (CreatePostResponse);
   rpc GetPost(GetPostRequest) returns (GetPostResponse);
   rpc ListPostsByUser(ListPostsByUserRequest) returns (ListPostsByUserResponse);
   rpc DeletePost(DeletePostRequest) returns (DeletePostResponse);
+  rpc CreatePostIndexedByUser(CreatePostIndexedByUserRequest) returns (CreatePostIndexedByUserResponse);
+  rpc InitializePostEngagements(InitializePostEngagementsRequest) returns (InitializePostEngagementsResponse);
 }
 
 // Request/Response messages

--- a/services/post-service/cmd/client/main.go
+++ b/services/post-service/cmd/client/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"connectrpc.com/connect"
+	"github.com/joho/godotenv"
+	postsv1 "github.com/yaninyzwitty/threads-go-backend/gen/posts/v1"
+	"github.com/yaninyzwitty/threads-go-backend/gen/posts/v1/postsv1connect"
+	"github.com/yaninyzwitty/threads-go-backend/shared/pkg"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil {
+		slog.Error("failed to load .env", "error", err)
+		os.Exit(1)
+	}
+
+	cfg := pkg.Config{}
+
+	if err := cfg.LoadConfig("config.yaml"); err != nil {
+		slog.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	// set up http client
+	httpClient := http.DefaultClient
+	postServiceUrl := fmt.Sprintf("http://localhost:%d", cfg.PostServer.Port)
+
+	slog.Info("post service url", "url", postServiceUrl)
+
+	postServiceClient := postsv1connect.NewPostServiceClient(
+		httpClient,
+		postServiceUrl,
+	)
+
+	req := connect.NewRequest(&postsv1.CreatePostRequest{
+		Content: "May you go have to encounter The Spirit of Truth and power of God💡",
+		ImageUrl: `https://scontent-mba2-1.cdninstagram.com/o1/v/t2/f2/m86/AQNm5cBEf4veFEtNemRm_BbjWtZRPuWjnAB583btNs-2pnD07bod28F_nziahODsF1eS9Y1CS6-0QBcCiMoPBjjY9u5y_bhKuT5ioIk.mp4?_nc_cat=101&_nc_sid=5e9851&_nc_ht=scontent-mba2-1.cdninstagram.com&_nc_ohc=H-ngvpH8nRIQ7kNvwEFKL36&efg=eyJ2ZW5jb2RlX3RhZyI6Inhwdl9wcm9ncmVzc2l2ZS5JTlNUQUdSQU0uRkVFRC5DMy43MjAuZGFzaF9iYXNlbGluZV8xX3YxIiwieHB2X2Fzc2V0X2lkIjoxMDcxNjEyNDk4MzY1Nzk5LCJ2aV91c2VjYXNlX2lkIjoxMDA5OSwiZHVyYXRpb25fcyI6MTczLCJ1cmxnZW5fc291cmNlIjoid3d3In0%3D&ccb=17-1&vs=bc129a65b09d3a17&_nc_vs=HBksFQIYUmlnX3hwdl9yZWVsc19wZXJtYW5lbnRfc3JfcHJvZC83QzRDRDE5REUyRkEwOEJBNkQxQUEyQzIxNjZDRjI5RF92aWRlb19kYXNoaW5pdC5tcDQVAALIARIAFQIYOnBhc3N0aHJvdWdoX2V2ZXJzdG9yZS9HSWRvcVI3SHJfLWg0WllPQU9Ebl9mcHNiWGcwYnFfRUFBQUYVAgLIARIAKAAYABsCiAd1c2Vfb2lsATEScHJvZ3Jlc3NpdmVfcmVjaXBlATEVAAAmzrXqpIeo5wMVAigCQzMsF0BlrMzMzMzNGBJkYXNoX2Jhc2VsaW5lXzFfdjERAHXqB2XmnQEA&_nc_zt=28&oh=00_AfTdN5lyjQSjsXXjAfOjZkuWhFcGvm6Eu7gISOFLwY9sGg&oe=686F5476
+`,
+		UserId: 145176544220827254,
+	})
+
+	req.Header().Set("Authorization", "Bearer "+os.Getenv("ACCESS_TOKEN"))
+
+	res, err := postServiceClient.CreatePost(context.TODO(), req)
+	if err != nil {
+		slog.Error("failed to create post", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("post created", "post_id", res.Msg.Post.Id)
+
+}

--- a/services/post-service/controller/post-controller.go
+++ b/services/post-service/controller/post-controller.go
@@ -28,8 +28,6 @@ func (c *PostController) CreatePost(ctx context.Context, req *connect.Request[po
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid request"))
 	}
 
-	// TODO-remove user id from arguments
-
 	// get user from context
 	user, err := auth.GetUserFromContext(ctx)
 	if err != nil {
@@ -144,4 +142,40 @@ func (c *PostController) DeletePost(
 	return connect.NewResponse(&postsv1.DeletePostResponse{
 		Success: true,
 	}), nil
+}
+
+func (c *PostController) InitializePostEngagements(
+	ctx context.Context,
+	req *connect.Request[postsv1.InitializePostEngagementsRequest],
+) (*connect.Response[postsv1.InitializePostEngagementsResponse], error) {
+	if req.Msg.PostId == 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("post id is required"))
+	}
+
+	if err := c.postsRepo.InsertEngagementsCount(ctx, req.Msg.PostId); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to initialize post engagements"))
+	}
+
+	return connect.NewResponse(&postsv1.InitializePostEngagementsResponse{
+		True: true,
+	}), nil
+
+}
+func (c *PostController) CreatePostIndexedByUser(
+	ctx context.Context,
+	req *connect.Request[postsv1.CreatePostIndexedByUserRequest],
+) (*connect.Response[postsv1.CreatePostIndexedByUserResponse], error) {
+
+	if req.Msg.Post == nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("invalid fields"))
+	}
+
+	if err := c.postsRepo.CreatePostIndexedByUser(ctx, req.Msg.Post); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("failed to index post by user"))
+	}
+
+	return connect.NewResponse(&postsv1.CreatePostIndexedByUserResponse{
+		Success: true,
+	}), nil
+
 }

--- a/services/post-service/kafka/handler.go
+++ b/services/post-service/kafka/handler.go
@@ -1,0 +1,89 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/segmentio/kafka-go"
+	postsv1 "github.com/yaninyzwitty/threads-go-backend/gen/posts/v1"
+	"github.com/yaninyzwitty/threads-go-backend/services/post-service/controller"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func StartKafkaConsumer(ctx context.Context, kafkaReader *kafka.Reader, postController *controller.PostController) {
+	slog.Info("starting kafka consumer...")
+	eventHandlers := map[string]func([]byte) error{
+		"post.created": func(b []byte) error {
+			var event postsv1.OutboxEvent
+			if err := protojson.Unmarshal(b, &event); err != nil {
+				return fmt.Errorf("failed to unmarshal OutboxEvent JSON: %w", err)
+			}
+
+			var postCreatedEvent postsv1.Post
+			if err := protojson.Unmarshal([]byte(event.Payload), &postCreatedEvent); err != nil {
+				return fmt.Errorf("failed to unmarshal post created event payload: %w", err)
+			}
+
+			eg, egCtx := errgroup.WithContext(ctx)
+
+			eg.Go(func() error {
+				_, err := postController.CreatePostIndexedByUser(egCtx,
+					connect.NewRequest(&postsv1.CreatePostIndexedByUserRequest{
+						Post: &postCreatedEvent,
+					}))
+				return err
+			})
+
+			eg.Go(func() error {
+				_, err := postController.InitializePostEngagements(egCtx, connect.NewRequest(&postsv1.InitializePostEngagementsRequest{
+					PostId: postCreatedEvent.Id,
+				}))
+				return err
+			})
+			return eg.Wait()
+
+		},
+	}
+
+	go func() {
+		for {
+			msg, err := kafkaReader.ReadMessage(ctx)
+			if ctx.Err() != nil {
+				slog.Info("Kafka consumer shutting down...")
+				return
+			}
+			if err != nil {
+				slog.Error("failed to read Kafka message", "error", err)
+				continue
+			}
+
+			parts := strings.Split(string(msg.Key), ":")
+			if len(parts) != 2 {
+				slog.Warn("invalid Kafka message key format", "key", string(msg.Key))
+				continue
+			}
+
+			eventKey := parts[0]
+			handler, ok := eventHandlers[eventKey]
+			if !ok {
+				slog.Warn("no handler found for event key", "key", eventKey)
+				continue
+
+			}
+
+			if err := handler(msg.Value); err != nil {
+				slog.Error("event handler failed", "key", eventKey, "error", err)
+				continue
+			}
+
+			if err := kafkaReader.CommitMessages(ctx, msg); err != nil {
+				slog.Error("failed to commit kafka message", "error", err)
+			}
+		}
+	}()
+
+}

--- a/services/user-service/cmd/client/main.go
+++ b/services/user-service/cmd/client/main.go
@@ -41,19 +41,20 @@ func main() {
 		httpClient,
 		userServiceUrl,
 	)
-	req := connect.NewRequest(&userv1.FollowUserRequest{
-		FollowingId: 145176065684295286,
+	req := connect.NewRequest(&userv1.LoginUserRequest{
+		Email:    "nomad.molina@mail.com",
+		Password: "12345678",
 	})
 
 	req.Header().Set("Authorization", "Bearer "+os.Getenv("ACCESS_TOKEN"))
 
-	res, err := userServiceClient.FollowUser(context.Background(), req)
+	res, err := userServiceClient.LoginUser(context.Background(), req)
 
 	if err != nil {
 		slog.Error("failed to follow user ", "error", err)
 		os.Exit(1)
 	}
 
-	slog.Info("user followed", "success", res.Msg.Success)
+	slog.Info("user logged in", "token", res.Msg.AccessToken)
 
 }


### PR DESCRIPTION
…to PostService

- Implemented CreatePostIndexedByUser and InitializePostEngagements methods in PostService.
- Updated PostServiceClient and PostServiceHandler interfaces to include new methods.
- Added corresponding request and response message definitions in post.proto.
- Created client and server implementations for the new methods.
- Integrated Kafka consumer to handle post creation events and initialize engagements.
- Updated PostRepository to support indexing posts by user and inserting engagement counts.
- Modified client and server main functions to accommodate new functionalities.